### PR TITLE
don't import case-λ, treat like λ

### DIFF
--- a/algebraic/scribblings/algebraic-forms.scrbl
+++ b/algebraic/scribblings/algebraic-forms.scrbl
@@ -7,7 +7,7 @@
 @require[
   @for-label[
     (except-in algebraic/racket/base
-               λ lambda case-lambda let let* letrec let-values let*-values
+               λ lambda case-λ case-lambda let let* letrec let-values let*-values
                letrec-values case define define-values
                #%module-begin)
     algebraic/racket/base/forms


### PR DESCRIPTION
8.14 is causing a doc build failure because case-λ is now defined by racket, and it looks like an easy fix, just treat case-λ like λ in the scribble file.